### PR TITLE
Improvements/qr code expiry

### DIFF
--- a/src/pages/ReceivePage.vue
+++ b/src/pages/ReceivePage.vue
@@ -42,6 +42,19 @@
         class="text-blue-9 q-my-md"
         style="width:250px"
       />
+      <q-icon v-if="networkTimeDiff" name="info" class="q-ml-xs">
+        <q-menu class="q-pa-sm">
+          <div>
+            Detected that device does not match server time.
+            QR code expiration is adjusted
+          </div>
+          <div class="text-caption text-grey">
+            Device is {{ Math.round(Math.abs(networkTimeDiff/1000)) }}
+            second{{ Math.round(Math.abs(networkTimeDiff/1000)) == 1 ? '' : 's' }}
+            {{ networkTimeDiff > 0 ? 'behind' : 'ahead' }}
+          </div>
+        </q-menu>
+      </q-icon>
     </div>
 
     <q-dialog v-model="refreshQr" persistent>
@@ -374,7 +387,7 @@ export default defineComponent({
       if (!isBchMode.value) {
         const expiryDuration = currencyRateUpdateRate / 1000
         const expirationTimestamp = Math.floor(currentTimestamp + expiryDuration)
-        const diffSeconds = networkTimeDiff.value / 1000
+        const diffSeconds = networkTimeDiff.value ? networkTimeDiff.value / 1000 : 0
         const adjustedExpirationTimestamp = expirationTimestamp + diffSeconds  
         paymentUri += `&expires=${adjustedExpirationTimestamp}`
       }
@@ -767,6 +780,7 @@ export default defineComponent({
       refreshQrCountdown,
       qrExpirationTimer,
       showExpirationTimer,
+      networkTimeDiff,
       isBchMode,
     }
   },

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -24,7 +24,7 @@ export async function getNetworkTimeDiff() {
 // NOTE: change source, ideally watchtower
 export async function getServerTime() {
   const startRequestTime = Date.now()
-  const response = await axios.get(`https://commercehub.paytaca.com/api/time/`)
+  const response = await axios.get(`https://watchtower.cash/api/status/?timestamp_only=true`)
   const endRequestTime = Date.now()
   const requestDuration = startRequestTime - endRequestTime
 

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,33 @@
+import axios from 'axios'
+
+export async function getNetworkTimeDiff() {
+  // Network Time Protocol (NTP) to determine absolute server time
+  // https://stackoverflow.com/questions/1638337/the-best-way-to-synchronize-client-side-javascript-clock-with-server-date
+  const { serverTime } = await getServerTime()
+  const localTime = new Date()
+
+  const timeDifference = serverTime - localTime
+  // const adjustedTimeDiff = timeDifference + requestDuration
+
+  // ideally the adjustedTimeDiff is used but timeDifference gives zero error
+  // check by subtracting adjustedLocal - serverTime
+  const adjustedLocal = new Date(localTime.getTime() + timeDifference)
+  return {
+    localTime,
+    serverTime,
+    adjustedLocal,
+
+    timeDifference,
+  }
+}
+
+// NOTE: change source, ideally watchtower
+export async function getServerTime() {
+  const startRequestTime = Date.now()
+  const response = await axios.get(`https://commercehub.paytaca.com/api/time/`)
+  const endRequestTime = Date.now()
+  const requestDuration = startRequestTime - endRequestTime
+
+  const serverTime = new Date(response.data?.timestamp)
+  return { serverTime, requestDuration }
+}


### PR DESCRIPTION
Adjust expiration timestamp in qr code to server time instead of device's time