### PR TITLE
Fix/marketplace chat

### DIFF
--- a/src/components/marketplace/ChatDialog.vue
+++ b/src/components/marketplace/ChatDialog.vue
@@ -511,7 +511,7 @@ export default defineComponent({
           if (membersPubkeys.value?.includes(pubkey)) return
           membersPubkeys.value.push(pubkey)
         })
-      } else if (parsedData?.type == 'new_pubkey') {
+      } else if (parsedData?.type == 'new_pubkey' || parsedData?.type == 'pubkey') {
         if (typeof parsedData?.data === 'string' && !membersPubkeys.value?.includes(parsedData?.data)) {
           membersPubkeys.value.push(parsedData?.data)
         }

--- a/src/components/marketplace/ChatDialog.vue
+++ b/src/components/marketplace/ChatDialog.vue
@@ -511,7 +511,7 @@ export default defineComponent({
           if (membersPubkeys.value?.includes(pubkey)) return
           membersPubkeys.value.push(pubkey)
         })
-      } else if (parsedData?.type == 'pubkey') {
+      } else if (parsedData?.type == 'new_pubkey') {
         if (typeof parsedData?.data === 'string' && !membersPubkeys.value?.includes(parsedData?.data)) {
           membersPubkeys.value.push(parsedData?.data)
         }

--- a/src/marketplace/chat/keys.js
+++ b/src/marketplace/chat/keys.js
@@ -2,16 +2,13 @@ import crypto from 'crypto'
 import { backend } from "../backend"
 import * as secp from '@noble/secp256k1'
 import { SecureStoragePlugin } from "capacitor-secure-storage-plugin";
-import { Device } from "@capacitor/device";
+import { pushNotificationsManager } from 'src/boot/push-notifications';
 
 const AES_STORAGE_KEY = 'marketplace-chat-aes-key'
 
 let deviceId
 async function getDeviceId() {
-  if (!deviceId) {
-    const deviceIdResp = await Device.getId()
-    deviceId = deviceIdResp?.uuid
-  }
+  if (!deviceId) deviceId = await pushNotificationsManager.fetchDeviceId()
   return deviceId
 }
 


### PR DESCRIPTION
- Fix for marketplace order chats unable to decrypt messages
  - Fix outdated method for fetching capacitor device ID when creating/updating chat identity.
  - Unified fetching of Device ID for easier maintainability.
- Updated chat dialog websocket message type for capturing new pubkeys in chat session. 