### PR TITLE
Fix/android nav overlap

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,6 +1,9 @@
 @use "sass:math";
 
 // app global css in SCSS form
+body {
+  margin-bottom: env(safe-area-inset-bottom);
+}
 
 html,
 body,
@@ -148,4 +151,8 @@ body.body--dark,
 .slide-down-leave-to {
   transform: translateY(-100%);
   opacity: 0;
+}
+
+.fixed-bottom {
+  bottom: env(safe-area-inset-bottom);
 }

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -24,8 +24,8 @@ body.body--dark,
 
 .q-page.q-pa-md,
 .q-page[class*="q-pa-"] {
-  padding-top: calc(constant(safe-area-inset-top) + 16px) !important;
-  padding-top: calc(env(safe-area-inset-top) + 16px) !important;
+  padding-top: calc(env(safe-area-inset-top) + 12px) !important;
+  padding-bottom: calc(12px + env(safe-area-inset-bottom)) !important;
 }
 
 .text-brandblue {
@@ -155,4 +155,18 @@ body.body--dark,
 
 .fixed-bottom {
   bottom: env(safe-area-inset-bottom);
+}
+
+.fixed-bottom::after {
+  content: "";
+  height: calc(env(safe-area-inset-bottom)) !important;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: $dark-page !important;
+}
+
+body.body--light .fixed-bottom::after {
+  background-color: $brandlight !important;
 }

--- a/src/pages/marketplace/index.vue
+++ b/src/pages/marketplace/index.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page class="q-pa-md" style="padding-bottom: 4.5rem;">
-    <q-pull-to-refresh @refresh="refreshPage">
+    <q-pull-to-refresh @refresh="refreshPage" class="q-pb-xl">
       <MarketplaceHeader class="q-pl-md">
         <template v-slot:title>
           <div class="q-space">


### PR DESCRIPTION
## Description
- Fix issue on some android devices with navigation button overlapping with viewport
  - Added `env(safe-area-inset-bottom)` to body tag and `fixed-bottom` classes
- Other: added bottom padding to marketplace index page to account for footer.

## Screenshots (if applicable):
<img width="349" height="724" alt="Before (main page)" src="https://github.com/user-attachments/assets/fae1c2c6-3ce3-4adf-800b-31c2899f72ef" />
<img width="345" height="717" alt="Before" src="https://github.com/user-attachments/assets/26d0c10c-3941-40ee-9c6e-485abdb8d31b" />
<img width="347" height="729" alt="After fix" src="https://github.com/user-attachments/assets/4a71af02-d154-485f-be8a-5e60d1fb2abe" />


## Type of Change
- [x] UI improvements with no business logic changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Tested on android studio, using Pixel 9 Pro emulator.
  - Must enable 3 button navigation (Settings > System > Gestures)
  - Open app and check if footer still overlaps with navigation button
- Also tested in local dev server

## @mentions
Mention the person or team responsible for reviewing the proposed changes.